### PR TITLE
Fix open scanner and catalog barcode issues

### DIFF
--- a/backend/src/AI/Application/LlmProfileApplicationService.php
+++ b/backend/src/AI/Application/LlmProfileApplicationService.php
@@ -17,6 +17,7 @@ use App\SharedKernel\Domain\Id\LlmProfileId;
 use App\SharedKernel\Infrastructure\Security\AppSecretStringCipher;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use ValueError;
 
 final readonly class LlmProfileApplicationService
 {
@@ -216,7 +217,7 @@ final readonly class LlmProfileApplicationService
         $trimmed = trim($raw);
         try {
             return LlmProfileKind::from($trimmed);
-        } catch (\ValueError) {
+        } catch (ValueError) {
             throw new BadRequestHttpException('Invalid kind; expected openai or openai_compatible.');
         }
     }

--- a/backend/src/Catalog/Domain/Entity/Embeddable/BarcodeEmbeddable.php
+++ b/backend/src/Catalog/Domain/Entity/Embeddable/BarcodeEmbeddable.php
@@ -22,9 +22,13 @@ final class BarcodeEmbeddable
         $this->type = $barcode->getType();
     }
 
-    public function toValue(): Barcode
+    public function toValue(): ?Barcode
     {
-        $code = $this->code ?? '';
+        if (null === $this->code || '' === trim($this->code)) {
+            return null;
+        }
+
+        $code = $this->code;
         $type = $this->type ?? 'EAN';
 
         return new Barcode($code, $type);

--- a/backend/src/Scanner/Infrastructure/Command/ListenScannerDevicesCommand.php
+++ b/backend/src/Scanner/Infrastructure/Command/ListenScannerDevicesCommand.php
@@ -24,6 +24,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class ListenScannerDevicesCommand extends Command
 {
+    private const int DEVICE_CONFIGURATION_POLL_SECONDS = 5;
+
     public function __construct(
         private readonly ScannerDeviceRepository $deviceRepository,
         private readonly ScannerInputReceiver $scannerInputReceiver,
@@ -35,12 +37,7 @@ final class ListenScannerDevicesCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $style = new SymfonyStyle($input, $output);
-        $devices = $this->deviceRepository->findAllOrderedByName();
-        if ([] === $devices) {
-            $style->warning('No scanner devices configured.');
-
-            return Command::SUCCESS;
-        }
+        $devices = $this->waitForConfiguredDevices($style);
 
         $state = $this->openEvdevStreams($style, $devices);
         if (null === $state) {
@@ -52,6 +49,24 @@ final class ListenScannerDevicesCommand extends Command
         $this->closeEvdevStreams($state);
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<ScannerDevice>
+     */
+    private function waitForConfiguredDevices(SymfonyStyle $style): array
+    {
+        while (true) {
+            $devices = $this->deviceRepository->findAllOrderedByName();
+            if ([] !== $devices) {
+                return $devices;
+            }
+            $style->warning(\sprintf(
+                'No scanner devices configured. Checking again in %d seconds.',
+                self::DEVICE_CONFIGURATION_POLL_SECONDS,
+            ));
+            sleep(self::DEVICE_CONFIGURATION_POLL_SECONDS);
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Treat empty hydrated catalog barcode embeddables as absent values so catalog item creation with blank barcode input returns `barcode: null` instead of surfacing an invalid empty barcode.
- Keep `scanner:listen` alive while no scanner devices are configured so supervisor does not restart it as an unexpected short-lived process.
- Fixed an unrelated PHP-CS-Fixer import normalization needed for the backend style check to pass.

### Testing
- `composer phpstan` passes.
- `composer cs-fixer` passes.
- `composer phparkitect` passes.
- `composer qa` reaches `phpstan` successfully but is blocked at `phpmd` by the existing locked `pdepend/pdepend` signature incompatibility with the installed Symfony dependency-injection API.
- Runtime checked `scanner:listen` against a migrated temporary PostgreSQL database; it stayed alive with no scanner devices configured.
- Runtime checked POST `/api/catalog_items` with a whitespace barcode; response returns `barcode: null`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1de46479-8d52-440b-a859-a42461343821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1de46479-8d52-440b-a859-a42461343821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

